### PR TITLE
Implement basic gamification

### DIFF
--- a/BadBudget/app/src/main/java/com/example/badbudget/AddExpenseActivity.kt
+++ b/BadBudget/app/src/main/java/com/example/badbudget/AddExpenseActivity.kt
@@ -188,6 +188,7 @@ class AddExpenseActivity : AppCompatActivity() {
             FirestoreService.addExpense(expense) { success ->
                 if (success) {
                     Toast.makeText(this, "Expense added!", Toast.LENGTH_SHORT).show()
+                    GamificationManager.onExpenseLogged(this)
                     finish()
                 } else {
                     Toast.makeText(this, "Failed to add expense", Toast.LENGTH_SHORT).show()

--- a/BadBudget/app/src/main/java/com/example/badbudget/AwardsActivity.kt
+++ b/BadBudget/app/src/main/java/com/example/badbudget/AwardsActivity.kt
@@ -4,19 +4,49 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import android.widget.ImageView
+import android.widget.TextView
+import android.widget.RatingBar
+import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.example.badbudget.R.id
 
 class AwardsActivity : AppCompatActivity() {
 
     private lateinit var backButton: ImageView
+    private lateinit var textStreak: TextView
+    private lateinit var textBadges: TextView
+    private lateinit var progressPoints: CircularProgressIndicator
+    private lateinit var ratingBar: RatingBar
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_awards)
-        findViewById<ImageView>(id.backButton).setOnClickListener {
+        backButton = findViewById(id.backButton)
+        textStreak = findViewById(R.id.textStreak)
+        textBadges = findViewById(R.id.textBadges)
+        progressPoints = findViewById(R.id.progressPoints)
+        ratingBar = findViewById(R.id.ratingBar)
+
+        backButton.setOnClickListener {
             startActivity(Intent(this, DashboardActivity::class.java))
             finish()
         }
+        loadStats()
+    }
 
+    private fun loadStats() {
+        val uid = UserSession.id(this)
+        FirestoreService.getStats(uid) { stats ->
+            val s = stats ?: return@getStats
+            textStreak.text = "\uD83D\uDD25 ${s.loginStreak}-day streak!"
+            textBadges.text = s.badges.joinToString(", ")
+            progressPoints.progress = s.points.coerceAtMost(100)
+            ratingBar.rating = when {
+                s.points >= 80 -> 5f
+                s.points >= 60 -> 4f
+                s.points >= 40 -> 3f
+                s.points >= 20 -> 2f
+                else -> 1f
+            }
+        }
     }
 }

--- a/BadBudget/app/src/main/java/com/example/badbudget/BudgetsActivity.kt
+++ b/BadBudget/app/src/main/java/com/example/badbudget/BudgetsActivity.kt
@@ -74,6 +74,7 @@ class BudgetsActivity : AppCompatActivity() {
             FirestoreService.addOrUpdateBudget(budget) { success ->
                 if (success) {
                     Toast.makeText(this, "Budget saved", Toast.LENGTH_SHORT).show()
+                    GamificationManager.onBudgetAdded(this)
                     // clear inputs
                     editTextBudgetCategory.text.clear()
                     editTextBudgetMin.text.clear()

--- a/BadBudget/app/src/main/java/com/example/badbudget/FirestoreService.kt
+++ b/BadBudget/app/src/main/java/com/example/badbudget/FirestoreService.kt
@@ -106,4 +106,23 @@ object FirestoreService {
             .addOnSuccessListener { onComplete(true) }
             .addOnFailureListener { onComplete(false) }
     }
+
+    // ─── Gamification stats ────────────────────────────────────────────
+    fun getStats(userId: String, callback: (com.example.badbudget.models.GamificationStats?) -> Unit) {
+        db.collection("stats")
+            .document(userId)
+            .get()
+            .addOnSuccessListener { snap ->
+                callback(snap.toObject(com.example.badbudget.models.GamificationStats::class.java))
+            }
+            .addOnFailureListener { callback(null) }
+    }
+
+    fun saveStats(stats: com.example.badbudget.models.GamificationStats, onComplete: (Boolean) -> Unit) {
+        db.collection("stats")
+            .document(stats.userId)
+            .set(stats)
+            .addOnSuccessListener { onComplete(true) }
+            .addOnFailureListener { onComplete(false) }
+    }
 }

--- a/BadBudget/app/src/main/java/com/example/badbudget/GamificationManager.kt
+++ b/BadBudget/app/src/main/java/com/example/badbudget/GamificationManager.kt
@@ -1,0 +1,57 @@
+package com.example.badbudget
+
+import android.content.Context
+import com.example.badbudget.models.GamificationStats
+import com.google.firebase.firestore.ktx.toObject
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+object GamificationManager {
+
+    fun recordLogin(context: Context) {
+        val userId = UserSession.id(context)
+        if (userId.isBlank()) return
+
+        FirestoreService.getStats(userId) { current ->
+            val today = LocalDate.now()
+            val lastDate = current?.lastLoginDate?.let {
+                runCatching { LocalDate.parse(it) }.getOrNull()
+            }
+            val newStreak = when {
+                lastDate == null -> 1
+                lastDate.plusDays(1) == today -> current!!.loginStreak + 1
+                lastDate == today -> current!!.loginStreak
+                else -> 1
+            }
+            val updated = (current ?: GamificationStats(userId = userId)).copy(
+                lastLoginDate = today.format(DateTimeFormatter.ISO_DATE),
+                loginStreak = newStreak,
+                points = (current?.points ?: 0) + 1
+            )
+            FirestoreService.saveStats(updated){}
+        }
+    }
+
+    fun onBudgetAdded(context: Context) {
+        updateBadge(context, "first_budget", 10)
+    }
+
+    fun onExpenseLogged(context: Context) {
+        updateBadge(context, "first_expense", 5)
+    }
+
+    private fun updateBadge(context: Context, badge: String, pts: Int) {
+        val userId = UserSession.id(context)
+        if (userId.isBlank()) return
+        FirestoreService.getStats(userId) { current ->
+            val stats = current ?: GamificationStats(userId = userId)
+            if (!stats.badges.contains(badge)) {
+                val updated = stats.copy(
+                    badges = stats.badges + badge,
+                    points = stats.points + pts
+                )
+                FirestoreService.saveStats(updated){}
+            }
+        }
+    }
+}

--- a/BadBudget/app/src/main/java/com/example/badbudget/LoginActivity.kt
+++ b/BadBudget/app/src/main/java/com/example/badbudget/LoginActivity.kt
@@ -50,6 +50,7 @@ class LoginActivity : AppCompatActivity() {
                         Toast.makeText(this, "Login successful!", Toast.LENGTH_SHORT).show()
                         val uid = auth.currentUser?.uid ?: ""
                         UserSession.init(this, uid)
+                        GamificationManager.recordLogin(this)
                         startActivity(Intent(this, DashboardActivity::class.java))
                         finish()
                     } else {

--- a/BadBudget/app/src/main/java/com/example/badbudget/models/GamificationStats.kt
+++ b/BadBudget/app/src/main/java/com/example/badbudget/models/GamificationStats.kt
@@ -1,0 +1,9 @@
+package com.example.badbudget.models
+
+data class GamificationStats(
+    val userId: String = "",
+    val lastLoginDate: String = "",
+    val loginStreak: Int = 0,
+    val points: Int = 0,
+    val badges: List<String> = emptyList()
+)

--- a/BadBudget/app/src/main/res/layout/activity_awards.xml
+++ b/BadBudget/app/src/main/res/layout/activity_awards.xml
@@ -76,9 +76,10 @@
 
             <!-- Daily streak -->
             <TextView
+                android:id="@+id/textStreak"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="\uD83D\uDD25 12-day streak!"
+                android:text="\uD83D\uDD25 0-day streak!"
                 android:textStyle="bold"
                 android:textSize="16sp" />
 
@@ -148,10 +149,11 @@
 
             <!-- Badge -->
             <TextView
+                android:id="@+id/textBadges"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
-                android:text="First Budget Set!"
+                android:text=""
                 android:textSize="14sp" />
 
             <LinearLayout
@@ -169,21 +171,24 @@
 
 
                 <com.google.android.material.progressindicator.CircularProgressIndicator
+                    android:id="@+id/progressPoints"
                     android:layout_width="120dp"
                     android:layout_height="120dp"
                     android:indeterminate="false"
                     app:indicatorSize="120dp"
                     app:trackThickness="12dp"
-                    android:progress="70"
+                    android:progress="0"
                     android:layout_marginStart="16dp" />
             </LinearLayout>
 
-            <ImageView
-                android:layout_width="140dp"
-                android:layout_height="62dp"
+            <RatingBar
+                android:id="@+id/ratingBar"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-                android:contentDescription="Star rating"
-                android:src="@drawable/ic_stars" />
+                android:isIndicator="true"
+                android:numStars="5"
+                android:stepSize="1" />
         </LinearLayout>
     </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- wire up gamification screen
- track login streaks, badges and points in Firestore
- show progress ring and star rating from points
- award achievements when adding a budget or logging an expense

## Testing
- `./gradlew test` *(fails: No route to host)*